### PR TITLE
avoid collision contract names 2

### DIFF
--- a/contracts/mock/HEZTokenFull.sol
+++ b/contracts/mock/HEZTokenFull.sol
@@ -2,43 +2,8 @@
 
 pragma solidity 0.6.12;
 
-interface IERC20 {
-    function totalSupply() external view returns (uint256);
-
-    function balanceOf(address account) external view returns (uint256);
-
-    function allowance(address owner, address spender)
-        external
-        view
-        returns (uint256);
-
-    function approve(address spender, uint256 amount) external returns (bool);
-
-    function transfer(address recipient, uint256 amount)
-        external
-        returns (bool);
-
-    function transferFrom(
-        address sender,
-        address recipient,
-        uint256 amount
-    ) external returns (bool);
-}
-
-// A library for performing overflow-safe math, courtesy of DappHub: https://github.com/dapphub/ds-math/blob/d0ef6d6a5f/src/math.sol
-// Modified to include only the essentials
-library SafeMath {
-    string private constant ERROR_ADD_OVERFLOW = "MATH:ADD_OVERFLOW";
-    string private constant ERROR_SUB_UNDERFLOW = "MATH:SUB_UNDERFLOW";
-
-    function add(uint256 x, uint256 y) internal pure returns (uint256 z) {
-        require((z = x + y) >= x, ERROR_ADD_OVERFLOW);
-    }
-
-    function sub(uint256 x, uint256 y) internal pure returns (uint256 z) {
-        require((z = x - y) <= x, ERROR_SUB_UNDERFLOW);
-    }
-}
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/math/SafeMath.sol";
 
 // Lightweight token modelled after UNI-LP:
 // https://github.com/Uniswap/uniswap-v2-core/blob/v1.0.1/contracts/UniswapV2ERC20.sol

--- a/package.json
+++ b/package.json
@@ -57,6 +57,6 @@
     "solidity-coverage": "^0.7.9",
     "solidity-docgen": "^0.5.4",
     "web3": "^1.2.11",
-    "@hermeznetwork/commonjs": "0.0.5"
+    "@hermeznetwork/commonjs": "0.0.7"
   }
 }


### PR DESCRIPTION
Solves: TOB 22. Contract name duplication leaves codebase error-prone 