### PR TITLE
Includes argument with coordinator address

### DIFF
--- a/scripts/deployment-testnet/deploy.js
+++ b/scripts/deployment-testnet/deploy.js
@@ -26,6 +26,9 @@ const tokenInitialAmount = ethers.BigNumber.from(
   "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
 );
 
+const NARGS_WITH_BOOT_COORDINATOR_ADDRESS=3;
+const BOOT_COORDINATOR_ADDRESS_POSITION=2;
+
 async function main() {
 
   // compìle contracts
@@ -61,7 +64,7 @@ async function main() {
   const donationAddress =
     deployParameters[chainId].donationAddress ||
     (await donationEthers.getAddress());
-  const bootCoordinatorAddress =
+  const bootCoordinatorAddress = process.argv.length == NARGS_WITH_BOOT_COORDINATOR_ADDRESS ? process.argv[BOOT_COORDINATOR_ADDRESS_POSITION] :
     deployParameters[chainId].bootCoordinatorAddress ||
     (await bootCoordinatorEthers.getAddress());
 

--- a/scripts/deployment-testnet/readme.md
+++ b/scripts/deployment-testnet/readme.md
@@ -11,7 +11,8 @@ In repository root:
      - rinkeby
      - goerli
      - ropsten
-6. `node deploy.js`
+6. `node deploy.js <coordinator-address>`
+**NOTE** coordinator-address is necessary only is different from deploy_parameters.json file
 
 # Guide:
 


### PR DESCRIPTION
Add one argument to specify coordinator address. I need to be able to specify the coordinator address when deploying in rinkeby so that coordinators do not collide. 
I need to pass an argument because i cant modify the json file easily from docker.