### PR TITLE
add verifier mock with gas consumption

### DIFF
--- a/contracts/hermez/test/VerifierGasTest.sol
+++ b/contracts/hermez/test/VerifierGasTest.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: AGPL-3.0
+
+pragma solidity ^0.6.12;
+import "../interfaces/VerifierRollupInterface.sol";
+
+contract VerifierGasTest {
+    VerifierRollupInterface verifier;
+
+    constructor (address _verifier) public {
+        verifier = VerifierRollupInterface(_verifier);
+    }
+
+    function gasVerifier(
+        uint256[2] calldata proofA,
+        uint256[2][2] calldata proofB,
+        uint256[2] calldata proofC,
+        uint256[1] calldata input
+    ) public view returns (uint256){
+        uint256 gasFirst = gasleft();
+        verifier.verifyProof(
+            proofA,
+            proofB,
+            proofC,
+            input
+        );
+        return (gasFirst - gasleft());
+    }
+}

--- a/contracts/hermez/test/VerifierRollupMock.sol
+++ b/contracts/hermez/test/VerifierRollupMock.sol
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: AGPL-3.0
+
+//
+// Copyright 2017 Christian Reitwiessner
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// 2019 OKIMS
+//      ported to solidity 0.6
+//      fixed linter warnings
+//      added requiere error messages
+//
+//
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.6.11;
+library Pairing {
+    struct G1Point {
+        uint X;
+        uint Y;
+    }
+    // Encoding of field elements is: X[0] * z + X[1]
+    struct G2Point {
+        uint[2] X;
+        uint[2] Y;
+    }
+    /// @return the generator of G1
+    function P1() internal pure returns (G1Point memory) {
+        return G1Point(1, 2);
+    }
+    /// @return the generator of G2
+    function P2() internal pure returns (G2Point memory) {
+        // Original code point
+        return G2Point(
+            [11559732032986387107991004021392285783925812861821192530917403151452391805634,
+             10857046999023057135944570762232829481370756359578518086990519993285655852781],
+            [4082367875863433681332203403145435568316851327593401208105741076214120093531,
+             8495653923123431417604973247489272438418190587263600148770280649306958101930]
+        );
+
+/*
+        // Changed by Jordi point
+        return G2Point(
+            [10857046999023057135944570762232829481370756359578518086990519993285655852781,
+             11559732032986387107991004021392285783925812861821192530917403151452391805634],
+            [8495653923123431417604973247489272438418190587263600148770280649306958101930,
+             4082367875863433681332203403145435568316851327593401208105741076214120093531]
+        );
+*/
+    }
+    /// @return r the negation of p, i.e. p.addition(p.negate()) should be zero.
+    function negate(G1Point memory p) internal pure returns (G1Point memory r) {
+        // The prime q in the base field F_q for G1
+        uint q = 21888242871839275222246405745257275088696311157297823662689037894645226208583;
+        if (p.X == 0 && p.Y == 0)
+            return G1Point(0, 0);
+        return G1Point(p.X, q - (p.Y % q));
+    }
+    /// @return r the sum of two points of G1
+    function addition(G1Point memory p1, G1Point memory p2) internal view returns (G1Point memory r) {
+        uint[4] memory input;
+        input[0] = p1.X;
+        input[1] = p1.Y;
+        input[2] = p2.X;
+        input[3] = p2.Y;
+        bool success;
+        // solium-disable-next-line security/no-inline-assembly
+        assembly {
+            success := staticcall(sub(gas(), 2000), 6, input, 0xc0, r, 0x60)
+            // Use "invalid" to make gas estimation work
+            switch success case 0 { invalid() }
+        }
+        require(success,"pairing-add-failed");
+    }
+    /// @return r the product of a point on G1 and a scalar, i.e.
+    /// p == p.scalar_mul(1) and p.addition(p) == p.scalar_mul(2) for all points p.
+    function scalar_mul(G1Point memory p, uint s) internal view returns (G1Point memory r) {
+        uint[3] memory input;
+        input[0] = p.X;
+        input[1] = p.Y;
+        input[2] = s;
+        bool success;
+        // solium-disable-next-line security/no-inline-assembly
+        assembly {
+            success := staticcall(sub(gas(), 2000), 7, input, 0x80, r, 0x60)
+            // Use "invalid" to make gas estimation work
+            switch success case 0 { invalid() }
+        }
+        require (success,"pairing-mul-failed");
+    }
+    /// @return the result of computing the pairing check
+    /// e(p1[0], p2[0]) *  .... * e(p1[n], p2[n]) == 1
+    /// For example pairing([P1(), P1().negate()], [P2(), P2()]) should
+    /// return true.
+    function pairing(G1Point[] memory p1, G2Point[] memory p2) internal view returns (bool) {
+        require(p1.length == p2.length,"pairing-lengths-failed");
+        uint elements = p1.length;
+        uint inputSize = elements * 6;
+        uint[] memory input = new uint[](inputSize);
+        for (uint i = 0; i < elements; i++)
+        {
+            input[i * 6 + 0] = p1[i].X;
+            input[i * 6 + 1] = p1[i].Y;
+            input[i * 6 + 2] = p2[i].X[0];
+            input[i * 6 + 3] = p2[i].X[1];
+            input[i * 6 + 4] = p2[i].Y[0];
+            input[i * 6 + 5] = p2[i].Y[1];
+        }
+        uint[1] memory out;
+        bool success;
+        // solium-disable-next-line security/no-inline-assembly
+        assembly {
+            success := staticcall(sub(gas(), 2000), 8, add(input, 0x20), mul(inputSize, 0x20), out, 0x20)
+            // Use "invalid" to make gas estimation work
+            switch success case 0 { invalid() }
+        }
+        require(success,"pairing-opcode-failed");
+        return out[0] != 0;
+    }
+    /// Convenience method for a pairing check for two pairs.
+    function pairingProd2(G1Point memory a1, G2Point memory a2, G1Point memory b1, G2Point memory b2) internal view returns (bool) {
+        G1Point[] memory p1 = new G1Point[](2);
+        G2Point[] memory p2 = new G2Point[](2);
+        p1[0] = a1;
+        p1[1] = b1;
+        p2[0] = a2;
+        p2[1] = b2;
+        return pairing(p1, p2);
+    }
+    /// Convenience method for a pairing check for three pairs.
+    function pairingProd3(
+            G1Point memory a1, G2Point memory a2,
+            G1Point memory b1, G2Point memory b2,
+            G1Point memory c1, G2Point memory c2
+    ) internal view returns (bool) {
+        G1Point[] memory p1 = new G1Point[](3);
+        G2Point[] memory p2 = new G2Point[](3);
+        p1[0] = a1;
+        p1[1] = b1;
+        p1[2] = c1;
+        p2[0] = a2;
+        p2[1] = b2;
+        p2[2] = c2;
+        return pairing(p1, p2);
+    }
+    /// Convenience method for a pairing check for four pairs.
+    function pairingProd4(
+            G1Point memory a1, G2Point memory a2,
+            G1Point memory b1, G2Point memory b2,
+            G1Point memory c1, G2Point memory c2,
+            G1Point memory d1, G2Point memory d2
+    ) internal view returns (bool) {
+        G1Point[] memory p1 = new G1Point[](4);
+        G2Point[] memory p2 = new G2Point[](4);
+        p1[0] = a1;
+        p1[1] = b1;
+        p1[2] = c1;
+        p1[3] = d1;
+        p2[0] = a2;
+        p2[1] = b2;
+        p2[2] = c2;
+        p2[3] = d2;
+        return pairing(p1, p2);
+    }
+}
+contract VerifierRollupMock {
+    using Pairing for *;
+    struct VerifyingKey {
+        Pairing.G1Point alfa1;
+        Pairing.G2Point beta2;
+        Pairing.G2Point gamma2;
+        Pairing.G2Point delta2;
+        Pairing.G1Point[] IC;
+    }
+    struct Proof {
+        Pairing.G1Point A;
+        Pairing.G2Point B;
+        Pairing.G1Point C;
+    }
+    function verifyingKey() internal pure returns (VerifyingKey memory vk) {
+        vk.alfa1 = Pairing.G1Point(20491192805390485299153009773594534940189261866228447918068658471970481763042,9383485363053290200918347156157836566562967994039712273449902621266178545958);
+        vk.beta2 = Pairing.G2Point([4252822878758300859123897981450591353533073413197771768651442665752259397132,6375614351688725206403948262868962793625744043794305715222011528459656738731], [21847035105528745403288232691147584728191162732299865338377159692350059136679,10505242626370262277552901082094356697409835680220590971873171140371331206856]);
+        vk.gamma2 = Pairing.G2Point([11559732032986387107991004021392285783925812861821192530917403151452391805634,10857046999023057135944570762232829481370756359578518086990519993285655852781], [4082367875863433681332203403145435568316851327593401208105741076214120093531,8495653923123431417604973247489272438418190587263600148770280649306958101930]);
+        vk.delta2 = Pairing.G2Point([15725659263853390664867018975702502312534083889606292066571659811301903761332,136809810005573829124547159299646511427247907026955052819928219198202674230], [18708930569170163144678326171474813071914035299419955122990534732110823847952,3579836367536932466340933761521993341619979174279603323130701425906242033843]);
+        vk.IC = new Pairing.G1Point[](2);
+        vk.IC[0] = Pairing.G1Point(4501471043992779294819821172515991595876982594419199041193945215591373991399,20107659135078383683311146731092902335405200733397716352207781717325356823754);
+        vk.IC[1] = Pairing.G1Point(7711864631878190704427190502523952390370077474895579996963799156591390229898,11473022540794270257715422500319012947641043172931746297385495356352174353538);
+
+    }
+    function verify(uint[] memory input, Proof memory proof) internal view returns (uint) {
+        uint256 snark_scalar_field = 21888242871839275222246405745257275088548364400416034343698204186575808495617;
+        VerifyingKey memory vk = verifyingKey();
+        require(input.length + 1 == vk.IC.length,"verifier-bad-input");
+        // Compute the linear combination vk_x
+        Pairing.G1Point memory vk_x = Pairing.G1Point(0, 0);
+        for (uint i = 0; i < input.length; i++) {
+            require(input[i] < snark_scalar_field,"verifier-gte-snark-scalar-field");
+            vk_x = Pairing.addition(vk_x, Pairing.scalar_mul(vk.IC[i + 1], input[i]));
+        }
+        vk_x = Pairing.addition(vk_x, vk.IC[0]);
+        if (!Pairing.pairingProd4(
+            Pairing.negate(proof.A), proof.B,
+            vk.alfa1, vk.beta2,
+            vk_x, vk.gamma2,
+            proof.C, vk.delta2
+        )) return 1;
+        return 0;
+    }
+    /// @return r  bool true if proof is valid
+    function verifyProof(
+            uint[2] memory a,
+            uint[2][2] memory b,
+            uint[2] memory c,
+            uint[1] memory input
+        ) public view returns (bool r) {
+        Proof memory proof;
+
+        proof.A = Pairing.G1Point(
+            12823142741947462018376637068611061184530582773186663424558261242088932958650,
+            15510239331731659263324114188636716065802904878544094401484954593592807049671);
+
+        proof.B = Pairing.G2Point(
+            [
+                4371287187348687214940133605217733703004883222445181026251086972719957113140,
+                638637090244761631320234407798004725080627654045822348011813051565608453553
+            ],
+            [
+                18997382790062900837772601169152115987807912448818596344809193940214862573620,
+                8789312473863924963986961093085972083579326466071861905150970567781475516666
+            ]);
+
+        proof.C = Pairing.G1Point(
+            15066023575175611296256118607366459860389282373417919892396785242139851111235,
+            20614173163416102479367448539231727763415631163149570165039228652167811930586
+        );
+
+        uint[] memory inputValues = new uint[](input.length);
+        for(uint i = 0; i < input.length; i++){
+            inputValues[i] = 13125286639093380931878518383173032474507961807467565131003538765912150608017;
+        }
+        verify(inputValues, proof);
+        return true;
+    }
+}

--- a/test/hermez/verifier-mock-gas.test.js
+++ b/test/hermez/verifier-mock-gas.test.js
@@ -1,0 +1,67 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const poseidonUnit = require("circomlib/src/poseidon_gencontract");
+const poseidonHashJs = require("circomlib").poseidon;
+const Scalar = require("ffjavascript").Scalar;
+const { smt } = require("circomlib");
+const babyJub = require("circomlib").babyJub;
+const utilsScalar = require("ffjavascript").utils;
+const axios = require("axios");
+const { RollupDB } = require("@hermeznetwork/commonjs");
+const SMTMemDB = require("circomlib").SMTMemDB;
+const { stringifyBigInts, unstringifyBigInts } = require("ffjavascript").utils;
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+describe("Hermez Helpers", function () {
+  this.timeout(0);
+  let iVerifier;
+  let iVerifierGas;
+
+  before(async function () {
+    // verifier
+    let verifierRollupMock = await ethers.getContractFactory(
+      "VerifierRollupMock"
+    );
+    iVerifier = await verifierRollupMock.deploy();
+    await iVerifier.deployed();
+
+    // call verifier gas
+    let verifierGas = await ethers.getContractFactory(
+      "VerifierGasTest"
+    );
+    iVerifierGas = await verifierGas.deploy(iVerifier.address);
+    await iVerifierGas.deployed();
+   });
+
+
+  it("verify proof precalculated", async function () {
+    const proofA = ["12823142741947462018376637068611061184530582773186663424558261242088932958650",
+      "15510239331731659263324114188636716065802904878544094401484954593592807049671"
+    ];
+    const proofB = [
+      [
+        "4371287187348687214940133605217733703004883222445181026251086972719957113140",
+        "638637090244761631320234407798004725080627654045822348011813051565608453553"
+      ],
+      [
+        "18997382790062900837772601169152115987807912448818596344809193940214862573620",
+        "8789312473863924963986961093085972083579326466071861905150970567781475516666"
+      ]
+    ];
+    const proofC =  ["15066023575175611296256118607366459860389282373417919892396785242139851111235",
+      "20614173163416102479367448539231727763415631163149570165039228652167811930586"
+    ];
+    const input = ["13125286639093380931878518383173032474507961807467565131003538765912150608017"];
+
+    const res = await iVerifierGas.gasVerifier(
+        proofA,
+        proofB,
+        proofC,
+        input,
+    );
+    console.log("Gas consumed: ", BigInt(res));
+  });
+});


### PR DESCRIPTION
This PR does the following:
- adds a mock `verifier`  contract which consumes gas as the real `verifier` does